### PR TITLE
Don/animated fade tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,14 +5,15 @@
 <br /> This is a component library created and used by Airship for quickly building out **consistent** and **high quality** React Native apps! It is made up of basic inputs and animated wrapper components. This library is included in all [Airfoil](https://github.com/teamairship/airfoil) templates by default.
 
 ## Features
+
 - ✨ Easy to use, configurable components
 - 📱 Animations that use the UI thread for a consistent 60fps on iOS and Android
 - ⏳ Saves you from building basic components from scratch every project
 
-
 ## Getting Started
 
 To add to your project, run the command
+
 ```
 yarn add @airship/rn-components
 ```
@@ -20,6 +21,7 @@ yarn add @airship/rn-components
 <br />
 
 ## Directory 📚
+
 - [@airship/rn-components](#airshiprn-components)
   - [Features](#features)
   - [Getting Started](#getting-started)
@@ -35,9 +37,11 @@ yarn add @airship/rn-components
 ## API Reference
 
 ### <b>AnimatedFade</b>
+
 An animated <b>View</b> that can wrap a React Native component fade a component in or fade it out.
 
 Example:
+
 ```
 import { AnimatedFade } from '@airship/rn-components';
 
@@ -45,14 +49,15 @@ import { AnimatedFade } from '@airship/rn-components';
   {children}
 </AnimatedFade>
 ```
+
 <img src="./assets/AnimatedFade.gif" width="473" height="941" />
 
 | Prop | Type | Required | Default | Description |
 | --- | :--: | :--: | :--: | --- |
-| <b>fadeOnMount</b> | <i>boolean</i> | no | `true` | AnimatedFade is set to fade in its opacity from `0` to `1` on render. |
-| <b>triggerFade</b> | <i>boolean</i> | no | `false` | Setting to `true` will cause the fade animation to start. |
-| <b>startingOpacity</b> | <i>number</i> | no | `0` | Defaults to `0`. Values can range from `0.0 - 1.0` |
-| <b>endingOpacity</b> | <i>number</i> | no | `1` | Defaults to `1`. Values can range from `0.0 - 1.0` |
+| <b>triggerFade</b> | <i>boolean</i> | no | `true` | By default, animation is triggered on mount. `triggerFade` allows for controlled triggering. |
+| <b>loop</b> | <i>boolean</i> | no | `false` | Enables looping for the animation |
+| <b>opacityStart</b> | <i>number</i> | no | `0` | Defaults to `0`. Values can range from `0.0 - 1.0` |
+| <b>opacityEnd</b> | <i>number</i> | no | `1` | Defaults to `1`. Values can range from `0.0 - 1.0` |
 | <b>duration</b> | <i>number</i> | no | `800` | Specify in `ms` how long the fade animation lasts. |
 | <b>delay</b> | <i>number</i> | no | `0` | Specify in `ms` how long to wait until the fade animation occurs. |
 | <b>style</b> | <i>ViewStyle</i> | no | `undefined` | Pass React Native `View` styles to `AnimatedFade`. |
@@ -62,9 +67,11 @@ import { AnimatedFade } from '@airship/rn-components';
 <br />
 
 ### <b>AnimatedMove</b>
+
 An animated <b>View</b> that can wrap a React Native component and move its position.
 
 Example:
+
 ```
 import { AnimatedMove } from '@airship/rn-components';
 
@@ -72,6 +79,7 @@ import { AnimatedMove } from '@airship/rn-components';
   {children}
 </AnimatedMove>
 ```
+
 <img src="./assets/AnimatedMove.gif" width="473" height="941" />
 
 | Prop | Type | Required | Default | Description |
@@ -92,9 +100,11 @@ import { AnimatedMove } from '@airship/rn-components';
 <br />
 
 ### <b>AnimatedPressable</b>
+
 An animated <b>View</b> that changes its scale on press, and returns to its original position on the press out. It can render out a component with props available to it such as color interpolation based on the pressed state.
 
 Example:
+
 ```
 import { AnimatedPressable } from '@airship/rn-components';
 
@@ -144,6 +154,7 @@ import { AnimatedPressable } from '@airship/rn-components';
   />
 </View>
 ```
+
 <img src="./assets/pressable.gif" width="473" height="941" />
 
 | Prop | Type | Required | Default | Description |
@@ -163,9 +174,11 @@ import { AnimatedPressable } from '@airship/rn-components';
 <br />
 
 ### <b>SegmentedControl</b>
+
 An animated tab controller for selections in an app with customizable color schemes.
 
 Example:
+
 ```
 import React, { useState } from 'react';
 import { StyleSheet } from 'react-native';
@@ -222,6 +235,7 @@ export const App = () => {
   })
 }
 ```
+
 <img src="./assets/segmented.gif" width="473" height="941" />
 
 | Prop | Type | Required | Default | Description |

--- a/src/AnimatedFade.tsx
+++ b/src/AnimatedFade.tsx
@@ -1,52 +1,108 @@
-import React, { useEffect, useRef } from 'react';
+import React, { useCallback, useEffect, useRef } from 'react';
 import { Animated, ViewStyle } from 'react-native';
+import useCurrent from './hooks/useCurrent';
 
 type Props = {
-  fadeOnMount?: boolean;
+  /**
+   * auto-trigger fade-in?
+   */
   triggerFade?: boolean;
-  startingOpacity?: number; // 0 - 1.00
-  endingOpacity?: number; // 0 - 1.00
-  duration?: number; // ms
-  delay?: number; // ms
+
+  /**
+   * starting opacity value (0 - 1.00)
+   */
+  opacityStart?: number;
+
+  /**
+   * ending opacity value (0 - 1.00)
+   */
+  opacityEnd?: number;
+
+  /**
+   * animation duration (in ms)
+   */
+  duration?: number;
+
+  /**
+   * delay before animation start (in ms)
+   */
+  delay?: number;
   style?: ViewStyle;
+
+  /**
+   * callback function called once fadeIn animation completes
+   */
   onEnd?: () => void;
+
+  /**
+   * should this animation repeat?
+   */
+  loop?: boolean;
 };
 
 const AnimatedFade: React.FC<Props> = ({
-  fadeOnMount = true,
-  triggerFade = false,
-  startingOpacity = 0,
-  endingOpacity = 1,
+  triggerFade = true,
+  opacityStart = 0,
+  opacityEnd = 1,
   duration = 800,
   delay = 0,
+  loop = false,
   onEnd,
   style,
   children,
 }) => {
-  const opacity = useRef(new Animated.Value(startingOpacity)).current;
+  const opacity = useRef(new Animated.Value(opacityStart));
 
-  const fade = () => {
-    Animated.timing(opacity, {
-      toValue: endingOpacity,
+  const _onEnd = useCurrent(onEnd);
+  const handleEnd = useCallback(() => {
+    if (_onEnd.current) _onEnd.current();
+  }, [_onEnd]);
+
+  const fadeIn = () => {
+    Animated.timing(opacity.current, {
+      toValue: opacityEnd,
       duration,
       delay,
       useNativeDriver: true,
     }).start((status) => {
-      if (status.finished && onEnd) {
-        onEnd();
+      if (status.finished) {
+        handleEnd();
+        if (loop) fadeOut();
       }
     });
   };
 
+  const fadeOut = () => {
+    Animated.timing(opacity.current, {
+      toValue: opacityStart,
+      duration,
+      delay,
+      useNativeDriver: true,
+    }).start((status) => {
+      if (status.finished) {
+        handleEnd();
+        if (loop) fadeIn();
+      }
+    });
+  };
+
+  const _fadeIn = useCurrent(fadeIn);
+
   useEffect(() => {
-    if (fadeOnMount || triggerFade) {
-      fade();
+    if (triggerFade) {
+      _fadeIn.current();
     }
-  }, [triggerFade, fadeOnMount]);
+  }, [triggerFade, _fadeIn]);
 
   return (
-    <Animated.View style={{ opacity, ...style }}>{children}</Animated.View>
+    <Animated.View style={{ opacity: opacity.current, ...style }}>
+      {children}
+    </Animated.View>
   );
 };
 
 export default AnimatedFade;
+
+const Test = () => {
+  return <AnimatedFade></AnimatedFade>;
+};

--- a/src/AnimatedFade.tsx
+++ b/src/AnimatedFade.tsx
@@ -102,7 +102,3 @@ const AnimatedFade: React.FC<Props> = ({
 };
 
 export default AnimatedFade;
-
-const Test = () => {
-  return <AnimatedFade></AnimatedFade>;
-};

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,0 +1,1 @@
+export { default as useCurrent } from './useCurrent';

--- a/src/hooks/useCurrent.ts
+++ b/src/hooks/useCurrent.ts
@@ -1,0 +1,24 @@
+import React from 'react';
+
+/**
+ * Set a ref to a variable's current value.
+ * This is useful for avoiding re-renders or re-triggers when including
+ * a variable in a useEffect dependency array.
+ *
+ * **USAGE:**
+ * ```
+ * const currentNumberRef = useCurrent(currentNumber);
+ * // currentNumberRef is always the same Javascript object,
+ * // so this avoids re-triggering the useEffect callback function.
+ * useEffect(() => {
+ *   console.log(currentNumberRef.current);
+ * }, [currentNumberRef]);
+ * ```
+ */
+const useCurrent = <T>(value: T): React.MutableRefObject<T> => {
+  const valueRef = React.useRef(value);
+  valueRef.current = value;
+  return valueRef;
+};
+
+export default useCurrent;

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -2,3 +2,4 @@ export { default as AnimatedFade } from './AnimatedFade';
 export { default as AnimatedMove } from './AnimatedMove';
 export { default as AnimatedPressable } from './AnimatedPressable';
 export { default as SegmentedControl } from './SegmentedControl';
+export * as hooks from './hooks';

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,3 +2,4 @@ export { default as AnimatedFade } from './AnimatedFade';
 export { default as AnimatedMove } from './AnimatedMove';
 export { default as AnimatedPressable } from './AnimatedPressable';
 export { default as SegmentedControl } from './SegmentedControl';
+export * as hooks from './hooks';


### PR DESCRIPTION
I needed to have a loop animation for Marathon Mobile. Thought I would add my changes here as well.

I made some Opinionated™️ changes - please let me know if you don't like anything!

**What this PR does:**

- make some tweaks to AnimatedFade component
    
    - add `loop` prop - this allows for looping animations
    - rename `startingOpacity` and `endingOpacity` for consistency with AnimatedPressable
    - add JSDoc comments for props (this allows details to show up in Intellisense - see screenshot)
    - add useCurrent hook

**Screenshots:**

DEMO of loop functionality in action: https://slack-files.com/T06MSPWQJ-F0224PW5G5A-bcbfe50be8

JSDoc comments allow intellisense while adding props - example:

![image](https://user-images.githubusercontent.com/5880655/118296722-47168e80-b4ab-11eb-9883-08f63ac75009.png)
