### PR TITLE
Adds children prop to AnimatedFade and AnimatedMove

### DIFF
--- a/src/AnimatedFade.tsx
+++ b/src/AnimatedFade.tsx
@@ -38,6 +38,7 @@ type Props = {
    * should this animation repeat?
    */
   loop?: boolean;
+  children?: React.ReactNode;
 };
 
 const AnimatedFade: React.FC<Props> = ({

--- a/src/AnimatedMove.tsx
+++ b/src/AnimatedMove.tsx
@@ -13,6 +13,7 @@ type AnimatedMoveProps = {
   delay?: number; // ms
   style?: ViewStyle;
   onEnd?: () => void;
+  children?: React.ReactNode;
 };
 
 const AnimatedMove: React.FC<AnimatedMoveProps> = ({


### PR DESCRIPTION
In v18 of React, they removed the implicit `children` prop from React.FC. 

This PR simply adds it back in explicitly to avoid this type error when using AnimatedMove or AnimatedFade.
![CleanShot 2023-01-09 at 15 14 13](https://user-images.githubusercontent.com/25647213/211419275-6d8a593e-a786-4464-827d-40d51b8105ac.png)
